### PR TITLE
fix(typos): fixed several spelling mistakes across the documents

### DIFF
--- a/docs/assent.rst
+++ b/docs/assent.rst
@@ -8,7 +8,7 @@ One of your challenges is to be able to present a compelling and believable visi
 
 **Your vision, however beautiful, will be quite useless if you're the only one who believes in it.**
 
-*Securing assent* is a quite different kind of communication from sharing a vision a vision. That is something like broadcasting. Securing assent by contrast is a two-way transaction - an exchange.
+*Securing assent* is a quite different kind of communication from sharing a vision. That is something like broadcasting. Securing assent by contrast is a two-way transaction -- an exchange.
 
 
 How belief works
@@ -16,7 +16,7 @@ How belief works
 
 We invest a vast amount of intellectual energy in the ideas that we think deserve it, to make them not just strong and believable, but deserving of belief. We make them intellectually rigorous, and understandable.
 
-The problem is that we we think this will make people believe them. Sadly, this is completely untrue.
+The problem is that we think this will make people believe them. Sadly, this is completely untrue.
 
 The fact is that **people believe ideas because the belief fits them comfortably**.
 

--- a/docs/assent.rst
+++ b/docs/assent.rst
@@ -123,7 +123,7 @@ It must not mean **distorting your vision, diluting your ambitions or obscuring 
 
 ..  admonition:: Example from documentation practice
 
-    I used many early conversations at Canonical to learn what was on people minds about documentation. Often, the language they used didn't align well with what I had planned - less that it disagreed, than failed to engage. I had to work hard to understand the needs being expressed in that language, and find ways to use the same language to show the value I had to offer, before expecting others to adopt my language.
+    I used many early conversations at Canonical to learn what was on people's minds about documentation. Often, the language they used didn't align well with what I had planned - less that it disagreed, than failed to engage. I had to work hard to understand the needs being expressed in that language, and find ways to use the same language to show the value I had to offer, before expecting others to adopt my language.
 
     Later, whenever I heard *my* language being repeated back to me, I knew that this was a point where someone had tried on an idea I was offering. This was them telling me that they found it comfortable to wear.
 

--- a/docs/building-a-team.rst
+++ b/docs/building-a-team.rst
@@ -15,7 +15,7 @@ There are two kinds of practitioners you need to consider:
 Specialists
 ===========
 
-You might find yourself working with an existing cohort of specialists - for example, techinical authors in documentation. Or you might need to build a team of specialists, from existing and new colleagues.
+You might find yourself working with an existing cohort of specialists - for example, technical authors in documentation. Or you might need to build a team of specialists, from existing and new colleagues.
 
 Either way, to be successful specialists need identity not only as a team, but also as a disciplinary group, professionals united by expertise and the values of their craft. They need:
 
@@ -56,9 +56,9 @@ You must find ways to give their role as your practitioner meaning, for them, in
 
 Both of these matter. Showing how serious the role is, and what sort of commitment it requires, will help you get agreement about *how much* you can ask of their time. But **showing value they create** is critical.
 
-Recognition is the key. Especially at the beginning, it will do no harm at all to make a strong point of it, explicitly hightlighting the value and the person who created it at every opportunity. Many people in the organisation will not at first understand what the value is and why it matters, but having a leader in the organisation point it out will show that it does.
+Recognition is the key. Especially at the beginning, it will do no harm at all to make a strong point of it, explicitly highlighting the value and the person who created it at every opportunity. Many people in the organisation will not at first understand what the value is and why it matters, but having a leader in the organisation point it out will show that it does.
 
-You will not have a career path or job definitions to offer these non-specialist practictioners. They already belong to their own discipline. But, you can define progress for them in a path that runs alongside that, marked by qualifications, achievements and other ways of recognising them.
+You will not have a career path or job definitions to offer these non-specialist practitioners. They already belong to their own discipline. But, you can define progress for them in a path that runs alongside that, marked by qualifications, achievements and other ways of recognising them.
 
 
 Competing demands on practitioners

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -44,4 +44,4 @@ Change - establishing new practice - is one aspect of your challenge. Another is
 
 Your only chance of success is once again to **build reinforcement into the practices you establish**. They must become self-tightening mechanisms, that ratchet tighter and not looser in response to the inevitable testing and tugging that they will inevitably subjected to. They must draw attention to themselves,  signalling their own integrity and correctness, and flagging their own failures.
 
-The numerous resources and tools presented in the handbook will help you do that, but you will need to find ways to adapt them to your own practice, and invent your owm.
+The numerous resources and tools presented in the handbook will help you do that, but you will need to find ways to adapt them to your own practice, and invent your own.

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -3,7 +3,7 @@
 Canonical Practice Leadership Handbook
 ======================================
 
-`Published version of the Practice Leadership Hndbook <https://documentation.ubuntu.com/canonical-practice-leadership-handbook/>`_.
+`Published version of the Practice Leadership Handbook <https://documentation.ubuntu.com/canonical-practice-leadership-handbook/>`_.
 
 The handbook supports the development of company-wide practice leadership at Canonical, but has also been used at much smaller scales, and could be useful in other organisations.
 

--- a/docs/securing-engagement.rst
+++ b/docs/securing-engagement.rst
@@ -82,7 +82,7 @@ Outcome
 
 *What shall this this encounter achieve?* 
 
-* "I want to indentify our top three priorities for x."
+* "I want to identify our top three priorities for x."
 * "After this workshop, you'll be ready for y."
 * "I'd like to introduce myself."
 

--- a/docs/sharing-your-vision.rst
+++ b/docs/sharing-your-vision.rst
@@ -32,7 +32,7 @@ There are good and bad ways to communicate a vision with other people.
 A technocratic blunder
 ------------------------
 
-At this stage, before you have been able to engage people in concrete activity, the true meaning of what you plan for them will not be apparent to them. The technocrat in you - the precision-minded, close-focused expert - may be tempted to address that by furnishing them with detail. Resist that that temptation: **more detail will not help get the significance of your project across to them**. On the contrary, it's a classic technocratic blunder that will hobble your own message.
+At this stage, before you have been able to engage people in concrete activity, the true meaning of what you plan for them will not be apparent to them. The technocrat in you - the precision-minded, close-focused expert - may be tempted to address that by furnishing them with detail. Resist that temptation: **more detail will not help get the significance of your project across to them**. On the contrary, it's a classic technocratic blunder that will hobble your own message.
 
 You're going to have to find other ways of getting your meaning across.
 
@@ -102,7 +102,7 @@ Having a message of outstanding clarity that conveys persuasive, compelling visi
 
 Authority is claimed as much as it is granted. The authority of your position will be marked by the very first time you address the organisation. Will it be tentatively, timidly, to small audiences? Or will you require the attention of the organisation as a whole to hear what *you* have to say, because *they* need to hear it?
 
-As a practice lead, you are not just entitled to claim that authority, but obliged to. Tthe worst thing you can do with authority is to abuse it, and the second-worst thing is to squander it.
+As a practice lead, you are not just entitled to claim that authority, but obliged to. The worst thing you can do with authority is to abuse it, and the second-worst thing is to squander it.
 
 **If you don't believe and assert with confidence that the organisation needs to hear your message, coming from you, about your vision - then nobody else will believe it either.**
 
@@ -128,6 +128,6 @@ It will seem sometimes that you have to do it endlessly, especially if your visi
 
 There is no way around that - but you can help yourself by developing a battery of resources to do some of this work for you, that all convey the same messages in different forms - presentations, weblog articles, conference talks, images, slogans - reminders of one kind or another that repeat the message.
 
-All these things need to be *forcefulful and unapologetic*. They need to reinforce what you say, not dilute it.
+All these things need to be *forceful and unapologetic*. They need to reinforce what you say, not dilute it.
 
 `Workbook - resources to carry your message <https://docs.google.com/document/d/18_OOHIZJ8SQASDjdrtgU9TzLSZDl0fa91eGfHQsODM4/edit?tab=t.0#heading=h.1f4pxjep7i2p>`_


### PR DESCRIPTION
This pull request focuses on correcting typos. The changes address spelling errors and duplicated words enhancing the overall readability and professionalism of the documentation.

## QA
1.  Read the code and check the corrected words are expected

Fixes https://github.com/canonical/practice-leadership-handbook/issues/4
Fixes https://github.com/canonical/practice-leadership-handbook/issues/2